### PR TITLE
gradle dependency download command dependent on version of ghidra

### DIFF
--- a/binocular/ghidra.py
+++ b/binocular/ghidra.py
@@ -130,6 +130,19 @@ class Ghidra(Disassembler):
             ["gradle", "buildGhidra"]
         ]
 
+        no_init_gradle_commit = repo.commit("30628db2d09d7b4ce46368b7522dc315e7b245c5")
+        target_commit = repo.commit(version)
+
+        common_ancestor = repo.merge_base(no_init_gradle_commit, target_commit)
+        if target_commit in common_ancestor:
+            # do nothing
+            pass
+        elif no_init_gradle_commit in common_ancestor:
+            # remove init in gradle command
+            del cmds[0][-1]
+        else:
+            raise Exception("Is {version} a valid commit hash?")
+
         for cmd in cmds:
             logger.info(f"$ {' '.join(cmd)}")
             out, err = run_proc(cmd=cmd, timeout=None, cwd=install_dir)

--- a/test/test_ghidra.py
+++ b/test/test_ghidra.py
@@ -20,6 +20,12 @@ def test_build_commit():
         Ghidra.install(version="1e4882d", build=True, install_dir=tmpdirname)
         assert Ghidra.is_installed(install_dir=tmpdirname)
 
+def test_build_commit_2():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        assert not Ghidra.is_installed(install_dir=tmpdirname)
+        Ghidra.install(version="7e6daf45e1c6a541bddeb8733eb21c4baa354c08", build=True, install_dir=tmpdirname)
+        assert Ghidra.is_installed(install_dir=tmpdirname)
+
 def test_disassm(make):
     assert Ghidra.is_installed()
     with Ghidra() as g:       


### PR DESCRIPTION
fixes the ghidra installation command

note: Need pyhidra 1.3.0 in order to work on ghidra 11.2+