### PR TITLE
43 migrate off of pyhidra

### DIFF
--- a/binocular/__init__.py
+++ b/binocular/__init__.py
@@ -1,3 +1,9 @@
+import coloredlogs
+import logging
+logger = logging.getLogger("BINocular")
+logger.addHandler(logging.FileHandler("logs.txt"))
+coloredlogs.install(
+    fmt="%(asctime)s %(name)s[%(process)d] %(levelname)s %(message)s")
 
 from .primitives import (
     Argument,

--- a/binocular/disassembler.py
+++ b/binocular/disassembler.py
@@ -41,6 +41,8 @@ class Disassembler(ABC):
         self._func_addrs: Dict[int, NativeFunction] = dict()
         self._bbs: Dict[int, BasicBlock] = dict()
         self._instrs: Dict[int, Instruction] = dict()
+        self.binary = None
+        self.functions = list()
 
     def __enter__(self):
         return self.open()

--- a/binocular/disassembler.py
+++ b/binocular/disassembler.py
@@ -8,17 +8,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any, Optional, Tuple, List, Dict, Set, IO
 
-import coloredlogs
 
 from .primitives import (BasicBlock, Binary, NativeFunction, SourceFunction,
                          Instruction, Section, Argument, Branch, IR, Reference, Variable)
 
 from .consts import Endian
-
-logger = logging.getLogger(__name__)
-coloredlogs.install(
-    fmt="%(asctime)s %(name)s[%(process)d] %(levelname)s %(message)s")
-
+from . import logger
 
 class Disassembler(ABC):
     '''
@@ -110,6 +105,7 @@ class Disassembler(ABC):
 
         count = 0
         for func_ctxt in self.get_func_iterator():
+            start = time.time()
             addr = self.get_func_addr(func_ctxt)
             func_name = self.get_func_name(addr, func_ctxt)
             logger.info(f"Processing: {func_name}")
@@ -168,6 +164,8 @@ class Disassembler(ABC):
             elif not f.thunk:
                 logger.warn(
                     f"[{self.name()}] {func_name} @ {addr} has 0 Basic Blocks")
+
+            logger.info(f"Analysis Pass 1 - {func_name}: {time.time()-start:.2f}s")
 
         # 2nd pass to do callee/callers
         for func_ctxt in self.get_func_iterator():

--- a/binocular/disassembler.py
+++ b/binocular/disassembler.py
@@ -99,7 +99,7 @@ class Disassembler(ABC):
         self.binary.strings |= set(
             self.get_strings(io_stream, len(self.binary)))
         io_stream.close()
-        
+
         self.functions = set()
 
         logger.info(
@@ -112,7 +112,7 @@ class Disassembler(ABC):
         for func_ctxt in self.get_func_iterator():
             addr = self.get_func_addr(func_ctxt)
             func_name = self.get_func_name(addr, func_ctxt)
-
+            logger.info(f"Processing: {func_name}")
             f = NativeFunction(
                 endianness=self.binary.endianness,
                 architecture=self.binary.architecture,

--- a/binocular/disassembler.py
+++ b/binocular/disassembler.py
@@ -460,7 +460,7 @@ class Disassembler(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_func_return_type(self, addr: int, func_ctxt: Any) -> int:
+    def get_func_return_type(self, addr: int, func_ctxt: Any) -> str:
         '''Returns the return type of the function corresponding to the function information returned from `get_func_iterator()`'''
         raise NotImplementedError
 

--- a/binocular/disassembler.py
+++ b/binocular/disassembler.py
@@ -99,7 +99,7 @@ class Disassembler(ABC):
         self.binary.strings |= set(
             self.get_strings(io_stream, len(self.binary)))
         io_stream.close()
-
+        
         self.functions = set()
 
         logger.info(

--- a/binocular/ghidra.py
+++ b/binocular/ghidra.py
@@ -34,7 +34,7 @@ class PipeRPC:
     Type-Length-Value Style Protocol
     **NOT** Thread or Multiprocess Safe *LMAO!!*
     '''
-    
+
     class Command(Enum):
         QUIT = 0
         TEST = 2
@@ -383,10 +383,10 @@ class Ghidra(Disassembler):
                 if len(out) > 0:
                     logger.info(str(out, 'utf8'))
                 if len(err) > 0:
-                    logger.warn(str(err, 'utf8'))
+                    logger.warning(str(err, 'utf8'))
             except TimeoutError:
                 self.ghidra_proc.kill()
-                logger.warn("Killed Ghidra Process. Took Too long")
+                logger.warning("Killed Ghidra Process. Took Too long")
 
         if self.stdout_reader.is_alive:
             self.stdout_reader.join()

--- a/binocular/primitives.py
+++ b/binocular/primitives.py
@@ -163,7 +163,7 @@ class Reference(BaseModel):
         return hash((self.from_, self.to, self.type.value))
 
     def __repr__(self):
-        return f"{hex(self.from_)} -{self.type.name}-> {hex(self._to)}"
+        return f"{hex(self.from_)} -{self.type.name}-> {hex(self.to)}"
 
     def orm(self):
         return ReferenceORM(
@@ -910,10 +910,10 @@ class Section(BaseModel):
     start: int
     offset: int
     size: int
-    entsize: int
-    link: int
-    info: int
-    align: int
+    entsize: int = 0
+    link: int = 0
+    info: int = 0
+    align: int = 0
 
     # flags
     write: bool = False

--- a/binocular/primitives.py
+++ b/binocular/primitives.py
@@ -185,8 +185,6 @@ class Argument(BaseModel):
     var_args: bool = False
     '''True when the argument is Variadic (i.e. more than one argument, like printf)'''
 
-    is_func_ptr: bool = False
-
     # TODO pydantic alias fields
     # so we can represent args in multiple langs?
 

--- a/binocular/rizin.py
+++ b/binocular/rizin.py
@@ -10,7 +10,6 @@ import pkgutil
 import binascii
 import requests
 import json
-import logging
 import tempfile
 import lzma
 import tarfile
@@ -20,15 +19,11 @@ from .disassembler import Disassembler
 from .primitives import Section, Instruction, IR, Branch, Argument, Reference, RefType, Variable
 from .consts import Endian, BranchType, IL
 from .utils import run_proc
+from . import logger
 
 from git import Repo
 import git
 import rzpipe
-import coloredlogs
-
-logger = logging.getLogger(__name__)
-coloredlogs.install(
-    fmt="%(asctime)s %(name)s[%(process)d] %(levelname)s %(message)s")
 
 
 class Rizin(Disassembler):

--- a/binocular/run.py
+++ b/binocular/run.py
@@ -67,6 +67,7 @@ def parse(
                 s.commit()
 
         if interactive:
+            print("Binary stored in variable 'b'")
             IPython.embed()
 
 

--- a/binocular/scripts/BinocularPipe.java
+++ b/binocular/scripts/BinocularPipe.java
@@ -249,9 +249,6 @@ public class BinocularPipe extends GhidraScript{
             out_buff.put(response);
 
         byte[] raw = out_buff.array();
-        // for (byte b: raw){
-        //     System.out.printf("%02X ", b);
-        // }
         out.write(raw, 0, raw.length);
         out.flush();
         
@@ -281,13 +278,7 @@ public class BinocularPipe extends GhidraScript{
                     this.basicBlockMap.put(addrWrap, bb);
                 }
             }
-            // if (bbAddr == 0x104000){
-            //     this.basicBlockMap.forEach((key, value) -> System.out.println(key + " " + value));
-            // }
         }   
-
-        // System.out.println(bbAddr);
-        // System.out.println(bb);
 
         switch(id){
             case TEST:

--- a/binocular/scripts/BinocularPipe.java
+++ b/binocular/scripts/BinocularPipe.java
@@ -1,0 +1,203 @@
+/*
+ Initialize all resources needed
+ Open up a named pipe specified by the parameters it gets called with
+ Wait for input and handle it
+    essentially an rpc implementation of disassembler.py
+ */
+
+//Makes functions out of a run of selected ARM or Thumb function pointers 
+//@category BINocular
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.HashMap;
+import java.nio.file.Paths;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+import ghidra.app.script.GhidraScript;
+
+import ghidra.program.model.symbol.SymbolTable;
+import ghidra.program.model.symbol.SymbolType;
+import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressIterator;
+import ghidra.program.model.symbol.SymbolType;
+import ghidra.program.model.listing.Listing;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Data;
+import ghidra.program.model.lang.LanguageDescription;
+import ghidra.program.model.lang.Endian;
+import ghidra.program.util.DefinedDataIterator;
+import ghidra.program.model.symbol.ExternalManager;
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.util.task.ConsoleTaskMonitor;
+import ghidra.program.model.block.CodeBlock;
+
+public class BinocularPipe extends GhidraScript{
+
+    @Override
+    public void run() throws Exception{
+        String[] args = this.getScriptArgs();
+        String rootPipePath = args[0];
+        String recvPath = Paths.get(rootPipePath, "send").toString();
+        String sendPath = Paths.get(rootPipePath, "recv").toString();
+
+        SymbolTable st = currentProgram.getSymbolTable();
+        FunctionManager fm = currentProgram.getFunctionManager();
+        LanguageDescription langDescript = currentProgram.getLanguage().getLanguageDescription();
+        ConsoleTaskMonitor monitor = new ConsoleTaskMonitor();
+        DecompInterface decomp = new DecompInterface();
+        decomp.openProgram(currentProgram);
+
+        HashMap<Long, CodeBlock> basicBlocMap = new HashMap<>();
+
+        boolean running = true;
+        while (running){
+            int id;
+            long bbAddr = 0;
+            long funcAddr = 0;
+            byte[] buff = new byte[8];
+            byte[] response;
+            int res_size = 0;
+
+            try(BufferedInputStream rpipe = new BufferedInputStream(new FileInputStream(new File(recvPath)))){
+                while(rpipe.available() == 0){
+                    // Waiting for Data
+                    Thread.sleep(100);
+                }
+                // System.out.println("Got Request!");
+
+                // Add some sort of timeout
+                id = rpipe.read();
+                if (id == 0){
+                    running = false;
+                }
+
+                rpipe.read(buff, 0, 8);
+                bbAddr = ByteBuffer.wrap(buff).getLong();
+
+                rpipe.read(buff, 0, 8);
+                funcAddr = ByteBuffer.wrap(buff).getLong();
+            }
+
+            response = this.handleCommand(id, bbAddr, funcAddr);
+            
+            if (response == null){
+                continue;
+            }
+
+            res_size = response.length;
+
+            try(BufferedOutputStream wpipe = new BufferedOutputStream(new FileOutputStream(new File(sendPath)))){
+                // For some reasone theres always a leading null byte... :(
+                ByteBuffer out_buff = ByteBuffer.allocate(res_size + 6);
+                out_buff.order(ByteOrder.BIG_ENDIAN);
+                out_buff.putChar((char)(id+1));
+                out_buff.putInt(res_size);
+                out_buff.put(response);
+
+                byte[] raw = out_buff.array();
+                // for (byte b: raw){
+                //     System.out.printf("%02X ", b);
+                // }
+                wpipe.write(raw, 0, raw.length);
+                wpipe.flush();
+            }
+
+        }
+    }
+
+    private byte[] handleCommand(int id, long bbAddr, long funcAddr){
+        switch(id){
+            case 2:
+                return this.smokeTest().getBytes();
+            case 4:
+                return this.getBinaryName().getBytes();
+            default:
+                return null;
+        }
+    }
+
+    public String smokeTest(){
+        return "BINocular Test";
+    }
+
+    public String getBinaryName(){
+        return currentProgram.getName();
+    }
+
+    public Address getEntryPoint(SymbolTable st, FunctionManager fm){
+        AddressIterator aIter = st.getExternalEntryPointIterator();
+        while (aIter.hasNext()){
+            Address addr = aIter.next();
+            Symbol sym = this.getSymbolAt(addr);
+            if (sym.getSymbolType().equals(SymbolType.FUNCTION)){
+                Function entry = fm.getFunctionAt(addr);
+                if (entry.getCallingConventionName() == "processEntry") {
+                    return addr;
+                } 
+            }
+        }
+        return null;
+    }
+
+    public String getArchitecture(LanguageDescription ld){
+        return ld.getProcessor().toString();
+    }
+
+    public Endian getEndianness(LanguageDescription ld){
+        return ld.getEndian();
+    }
+
+    public int getBitness(LanguageDescription ld){
+        return ld.getSize();
+    }
+
+    public Address getBaseAddress(){
+        return currentProgram.getImageBase();
+    }
+
+    public List<String> getStrings(){
+        LinkedList<String> list = new LinkedList<>();
+        for(Data d: DefinedDataIterator.definedStrings(currentProgram)){
+            list.add(d.getValue().toString());
+        }
+        return list;
+    }
+
+    public List<String> getDynamicLibs(){
+        LinkedList<String> libs = new LinkedList<>();
+        ExternalManager em = currentProgram.getExternalManager();
+        for(String name: em.getExternalLibraryNames()){
+            if (!name.equals("<EXTERNAL>")){
+                libs.add(name);
+            }
+        }
+
+        return libs;
+    }
+
+    public List<Function> getFunctionIterator(FunctionManager fm){
+        LinkedList<Function> funcs = new LinkedList<>();
+        for(Function f: fm.getFunctions(true)){
+            funcs.add(f);
+        }
+        return funcs;
+    }
+
+    public DecompileResults decompile(DecompInterface decomp, Function f, ConsoleTaskMonitor monitor){
+        return decomp.decompileFunction(f, 300, monitor);
+    }
+
+
+
+}

--- a/binocular/scripts/BinocularPipe.java
+++ b/binocular/scripts/BinocularPipe.java
@@ -691,7 +691,7 @@ public class BinocularPipe extends GhidraScript{
         return dFunc.getC();
     }
 
-    public List<Function> getFunctionCallees(Function f){
+    public List<Function> getFunctionCallers(Function f){
         LinkedList<Function> list = new LinkedList<>();
         for (Reference ref: rm.getReferencesTo(f.getEntryPoint())){
             if (ref.getReferenceType().isCall()){
@@ -704,7 +704,7 @@ public class BinocularPipe extends GhidraScript{
         return list;
     }
 
-    public List<Function> getFunctionCallers(Function f){
+    public List<Function> getFunctionCallees(Function f){
         LinkedList<Function> list = new LinkedList<>();
         for(Address addr: f.getBody().getAddresses(true)){
             for(Reference ref: rm.getReferencesFrom(addr)){
@@ -719,10 +719,19 @@ public class BinocularPipe extends GhidraScript{
     public List<Reference> getFunctionXRefs(Function f){
         LinkedList<Reference> refs = new LinkedList<>();
         for(Address addr: f.getBody().getAddresses(true)){
+            // For now, Skip stack refs because when
+            // You query their address, it just returns
+            // the relative offset from the top of the stack
             for(Reference r: rm.getReferencesFrom(addr)){
+                if (r.getToAddress().isStackAddress())
+                    continue;
+
                 refs.add(r);
             }
             for(Reference r: rm.getReferencesTo(addr)){
+                if (r.getFromAddress().isStackAddress())
+                    continue;
+
                 refs.add(r);
             }
         }

--- a/binocular/scripts/BinocularPipe.java
+++ b/binocular/scripts/BinocularPipe.java
@@ -11,6 +11,7 @@
 import java.util.LinkedList;
 import java.util.List;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.nio.file.Paths;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -41,8 +42,96 @@ import ghidra.app.decompiler.DecompInterface;
 import ghidra.app.decompiler.DecompileResults;
 import ghidra.util.task.ConsoleTaskMonitor;
 import ghidra.program.model.block.CodeBlock;
+import ghidra.program.model.pcode.HighFunction;
+import ghidra.program.model.pcode.FunctionPrototype;
+import ghidra.program.model.listing.Variable;
+import ghidra.app.decompiler.DecompiledFunction;
+import ghidra.program.util.DefinedDataIterator;
+import ghidra.program.model.symbol.ReferenceManager;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceType;
+import ghidra.program.model.block.BasicBlockModel;
+
+class BINVariable{
+    public String type;
+    public String name;
+    public boolean isRegister;
+    public boolean isStack;
+    public int stackOffset;
+
+    public BINVariable(String type, String name, boolean isRegister, boolean isStack){
+        this.type = type;
+        this.name = name;
+        this.isRegister = isRegister;
+        this.isStack = isStack;
+        this.stackOffset = 0;
+    }
+
+    public byte[] getBytes(){
+        int lengths = this.type.length() + this.name.length() + 2;
+
+        ByteBuffer buf = ByteBuffer.allocate(lengths + 6);
+        buf.order(ByteOrder.BIG_ENDIAN);
+        buf.put(this.type.getBytes());
+        buf.put((byte)0);
+        buf.put(this.name.getBytes());
+        buf.put((byte)0);
+        buf.put(this.isRegister ? (byte)1 : (byte)0);
+        buf.put(this.isStack ? (byte)1 : (byte)0);
+        buf.putInt(this.stackOffset);
+
+        return buf.array();
+    }
+}
 
 public class BinocularPipe extends GhidraScript{
+    // Fuck enums
+    final byte QUIT = 0;
+    final byte TEST = 2;
+    final byte BINARY_NAME = 4;
+    final byte ENTRY_POINT = 6;
+    final byte ARCHITECTURE = 8;
+    final byte ENDIANNESS = 10;
+    final byte BITNESS = 12;
+    final byte BASE_ADDR = 14;
+    final byte DYN_LIBS = 16;
+    final byte FUNCS = 18;
+    // final byte FUNC_ADDR = 20;
+    final byte FUNC_NAME = 22;
+    final byte FUNC_ARGS = 24;
+    final byte FUNC_RETURN = 26;
+    final byte FUNC_STACK_FRAME = 28;
+    final byte FUNC_CALLERS = 30;
+    final byte FUNC_CALLEES = 32;
+    final byte FUNC_XREFS = 34;
+    final byte FUNC_BB = 36;
+    final byte BB_ADDR = 38;
+    final byte BB_BRANCHES = 40;
+    final byte BB_INSTR = 42;
+    // final byte SECTIONS = 44;
+    final byte DECOMP = 46;
+    final byte FUNC_VARS = 48;
+    final byte INSTR_PCODE = 50;
+    final byte INSTR_COMMENT = 52;
+    final byte STRINGS = 54;
+
+    final byte UNKNOWN = 0;
+    final byte JUMP = 1;
+    final byte CALL = 2;
+    final byte READ = 3;
+    final byte WRITE = 4;
+    final byte DATA = 5;
+
+    SymbolTable st;
+    FunctionManager fm;
+    LanguageDescription ld;
+    BasicBlockModel bbm;
+    ReferenceManager rm;
+    ConsoleTaskMonitor monitor = new ConsoleTaskMonitor();
+    DecompInterface decomp = new DecompInterface();
+    HashMap<Long, CodeBlock> basicBlockMap = new HashMap<>();
+    HashMap<Function, DecompileResults> decompCache = new HashMap<>();
+    int timeout;
 
     @Override
     public void run() throws Exception{
@@ -51,14 +140,14 @@ public class BinocularPipe extends GhidraScript{
         String recvPath = Paths.get(rootPipePath, "send").toString();
         String sendPath = Paths.get(rootPipePath, "recv").toString();
 
-        SymbolTable st = currentProgram.getSymbolTable();
-        FunctionManager fm = currentProgram.getFunctionManager();
-        LanguageDescription langDescript = currentProgram.getLanguage().getLanguageDescription();
-        ConsoleTaskMonitor monitor = new ConsoleTaskMonitor();
-        DecompInterface decomp = new DecompInterface();
+        this.st = currentProgram.getSymbolTable();
+        this.fm = currentProgram.getFunctionManager();
+        this.ld = currentProgram.getLanguage().getLanguageDescription();
+        this.rm = currentProgram.getReferenceManager();
+        this.bbm = new BasicBlockModel(currentProgram);
+        // Gracious 5 min timeout for decompilation
+        this.timeout = 60 * 5;
         decomp.openProgram(currentProgram);
-
-        HashMap<Long, CodeBlock> basicBlocMap = new HashMap<>();
 
         boolean running = true;
         while (running){
@@ -78,7 +167,7 @@ public class BinocularPipe extends GhidraScript{
 
                 // Add some sort of timeout
                 id = rpipe.read();
-                if (id == 0){
+                if (id == QUIT){
                     running = false;
                 }
 
@@ -92,18 +181,18 @@ public class BinocularPipe extends GhidraScript{
             response = this.handleCommand(id, bbAddr, funcAddr);
             
             if (response == null){
-                continue;
+                res_size = 0;
+            }else{
+                res_size = response.length;
             }
 
-            res_size = response.length;
-
             try(BufferedOutputStream wpipe = new BufferedOutputStream(new FileOutputStream(new File(sendPath)))){
-                // For some reasone theres always a leading null byte... :(
-                ByteBuffer out_buff = ByteBuffer.allocate(res_size + 6);
+                ByteBuffer out_buff = ByteBuffer.allocate(res_size + 5);
                 out_buff.order(ByteOrder.BIG_ENDIAN);
-                out_buff.putChar((char)(id+1));
+                out_buff.put((byte)(id+1));
                 out_buff.putInt(res_size);
-                out_buff.put(response);
+                if (res_size > 0)
+                    out_buff.put(response);
 
                 byte[] raw = out_buff.array();
                 // for (byte b: raw){
@@ -117,14 +206,173 @@ public class BinocularPipe extends GhidraScript{
     }
 
     private byte[] handleCommand(int id, long bbAddr, long funcAddr){
+        Function f = null;
+        CodeBlock bb = null;
+
+        if (funcAddr != 0){
+            Address a = this.getAddress(funcAddr);
+            f = fm.getFunctionAt(a);
+        }
+
+        if (bbAddr != 0){
+            Long addrWrap = bbAddr;
+            bb = this.basicBlockMap.get(addrWrap);
+        }
+
         switch(id){
-            case 2:
+            case TEST:
                 return this.smokeTest().getBytes();
-            case 4:
+            case BINARY_NAME:
                 return this.getBinaryName().getBytes();
+            case ENTRY_POINT:
+                return this.packLong(this.getEntryPoint().getOffset());
+            case ARCHITECTURE:
+                return this.getArchitecture().getBytes();
+            case ENDIANNESS:
+                return this.getEndianness().getDisplayName().getBytes();
+            case BITNESS:
+                return this.packInt(this.getBitness());
+            case BASE_ADDR:
+                return this.packLong(this.getBaseAddress().getOffset());
+            case DYN_LIBS:
+                return this.packStringList(this.getDynamicLibs());
+            case FUNCS:
+                return this.packFunctionList(this.getFunctionIterator());
+            // case FUNC_ADDR:
+            //     return; // No need to implement since we are using function's address as a key to all function things
+            case FUNC_NAME:
+                return this.getFunctionName(f).getBytes();
+            case FUNC_ARGS:
+                return this.packStringList(this.getFunctionArgs(f));
+            case FUNC_RETURN:
+                return this.getFunctionReturnType(f).getBytes();
+            case FUNC_STACK_FRAME:
+                return this.packInt(this.getFunctionStackFrameSize(f));
+            case FUNC_CALLERS:
+                return this.packFunctionList(this.getFunctionCallers(f));
+            case FUNC_CALLEES:
+                return this.packFunctionList(this.getFunctionCallees(f));
+            case FUNC_XREFS:
+                return this.packReferenceList(this.getFunctionXRefs(f));
+            // case FUNC_BB:
+            //     return;
+            // case BB_ADDR:
+            //     return;
+            // case BB_BRANCHES:
+            //     return;
+            // case BB_INSTR:
+            //     return;
+            // case DECOMP:
+            //     return;
+            // case FUNC_VARS:
+            //     return;
+            // case INSTR_PCODE:
+            //     return;
+            // case INSTR_COMMENT:
+            //     return;
+            // case STRINGS:
+            //     return;
             default:
                 return null;
         }
+    }
+
+    private byte[] packLong(long l){
+        ByteBuffer buf = ByteBuffer.allocate(8);
+        buf.order(ByteOrder.BIG_ENDIAN);
+        buf.putLong(l);
+        return buf.array();
+    }
+
+    private byte[] packInt(int i){
+        ByteBuffer buf = ByteBuffer.allocate(4);
+        buf.order(ByteOrder.BIG_ENDIAN);
+        buf.putInt(i);
+        return buf.array();
+    }
+
+    private byte[] packStringList(List<String> list){
+        int total_length = 0;
+        LinkedList<byte[]> raw_list = new LinkedList<byte[]>();
+        for (String s: list){
+            byte[] encoded = s.getBytes();
+            raw_list.add(encoded);
+            total_length += encoded.length + 1;
+        }
+
+        if (total_length == 0)
+            return null;
+
+        ByteBuffer buf = ByteBuffer.allocate(total_length);
+        buf.order(ByteOrder.BIG_ENDIAN);
+        for (byte[] b: raw_list){
+            buf.put(b);
+            buf.put((byte)0);
+        }
+
+        return buf.array();
+    }
+
+    private byte[] packFunctionList(List<Function> list){
+        if (list.size() == 0)
+            return null;
+
+        ByteBuffer buf = ByteBuffer.allocate(8 * list.size());
+        buf.order(ByteOrder.BIG_ENDIAN);
+        for (Function f: list){
+            buf.putLong(f.getEntryPoint().getOffset());
+        }
+        return buf.array();
+    }
+
+    private byte[] packVariableList(List<BINVariable> list){
+        if (list.size() == 0)
+            return null;
+
+        // Pascal String Style (length then data)
+        int total_length = 0;
+        LinkedList<byte[]> raw_list = new LinkedList<byte[]>();
+        for(BINVariable var: list){
+            byte[] encoded = var.getBytes();
+            raw_list.add(encoded);
+            total_length += encoded.length + 4;
+        }
+        ByteBuffer buf = ByteBuffer.allocate(total_length);
+        buf.order(ByteOrder.BIG_ENDIAN);
+        for (byte[] b: raw_list){
+            buf.putInt(b.length);
+            buf.put(b);
+        }
+
+        return buf.array();
+    }
+
+    private byte[] packReferenceList(List<Reference> refs){
+        int total_length = refs.size() * (1+8+8); // 1 bytes + 2 longs
+        ByteBuffer buf = ByteBuffer.allocate(total_length);
+        buf.order(ByteOrder.BIG_ENDIAN);
+        for(Reference r: refs){
+            ReferenceType rType = r.getReferenceType();
+            if (rType.isCall()){
+                buf.put(CALL);
+            }else if (rType.isJump()){
+                buf.put(JUMP);
+            }else if (rType.isRead()){
+                buf.put(READ);
+            }else if (rType.isWrite()){
+                buf.put(WRITE);
+            }else{
+                buf.put((byte)0);
+            }
+
+            buf.putLong(r.getToAddress().getOffset());
+            buf.putLong(r.getFromAddress().getOffset());
+        }
+        return buf.array();
+    }
+
+    private Address getAddress(long addr){
+        return currentProgram.getAddressFactory().getDefaultAddressSpace().getAddress(addr);
     }
 
     public String smokeTest(){
@@ -135,7 +383,7 @@ public class BinocularPipe extends GhidraScript{
         return currentProgram.getName();
     }
 
-    public Address getEntryPoint(SymbolTable st, FunctionManager fm){
+    public Address getEntryPoint(){
         AddressIterator aIter = st.getExternalEntryPointIterator();
         while (aIter.hasNext()){
             Address addr = aIter.next();
@@ -150,15 +398,15 @@ public class BinocularPipe extends GhidraScript{
         return null;
     }
 
-    public String getArchitecture(LanguageDescription ld){
+    public String getArchitecture(){
         return ld.getProcessor().toString();
     }
 
-    public Endian getEndianness(LanguageDescription ld){
+    public Endian getEndianness(){
         return ld.getEndian();
     }
 
-    public int getBitness(LanguageDescription ld){
+    public int getBitness(){
         return ld.getSize();
     }
 
@@ -186,7 +434,7 @@ public class BinocularPipe extends GhidraScript{
         return libs;
     }
 
-    public List<Function> getFunctionIterator(FunctionManager fm){
+    public List<Function> getFunctionIterator(){
         LinkedList<Function> funcs = new LinkedList<>();
         for(Function f: fm.getFunctions(true)){
             funcs.add(f);
@@ -194,10 +442,136 @@ public class BinocularPipe extends GhidraScript{
         return funcs;
     }
 
-    public DecompileResults decompile(DecompInterface decomp, Function f, ConsoleTaskMonitor monitor){
-        return decomp.decompileFunction(f, 300, monitor);
+    public String getFunctionName(Function f){
+        return f.getName();
     }
 
+    private DecompileResults decompile(Function f){
+        DecompileResults res = decompCache.get(f);
+        if (res != null){
+            return res;
+        }
 
+        return decomp.decompileFunction(f, timeout, monitor);
+    }
+
+    public List<String> getFunctionArgs(Function f){
+        LinkedList<String> args = new LinkedList<>();
+        DecompileResults res = this.decompile(f);
+        HighFunction high = res.getHighFunction();
+        if (high == null){
+            return args;
+        }
+
+        FunctionPrototype proto = high.getFunctionPrototype();
+
+        int numParams = proto.getNumParams();
+        for(int i = 0; i < numParams; i++){
+            args.add(
+                proto.getParam(i).getDataType().toString() +
+                " " +
+                proto.getParam(i).getName().toString()
+            );
+        }
+
+        if (f.hasVarArgs()){
+            args.add("...");
+        }
+
+        return args;
+    }
+
+    public String getFunctionReturnType(Function f){
+        DecompileResults res = this.decompile(f);
+        HighFunction high = res.getHighFunction();
+        if (high == null){
+            return null;
+        }
+
+        return high.getFunctionPrototype().getReturnType().toString();        
+    }
+
+    public int getFunctionStackFrameSize(Function f){
+        return f.getStackFrame().getFrameSize();
+    }
+
+    public List<BINVariable> getFunctionVars(Function f){
+        LinkedList<BINVariable> vars = new LinkedList<>();
+        for(Variable v: f.getLocalVariables()){
+            BINVariable var = new BINVariable(v.getDataType().getName().toString(), v.getName().toString(), v.isRegisterVariable(), v.isStackVariable());
+            if (var.isStack){
+                var.stackOffset = v.getStackOffset();
+            }
+            vars.add(var);
+        }
+        return vars;
+    }
+    
+    public boolean isThunk(Function f){
+        return f.isThunk();
+    }
+
+    public String getFunctionDecompilation(Function f){
+        DecompileResults res = this.decompile(f);
+        DecompiledFunction dFunc = res.getDecompiledFunction();
+        if (dFunc == null){
+            return null;
+        }
+
+        return dFunc.getC();
+    }
+
+    public List<Function> getFunctionCallees(Function f){
+        LinkedList<Function> list = new LinkedList<>();
+        for (Reference ref: rm.getReferencesTo(f.getEntryPoint())){
+            if (ref.getReferenceType().isCall()){
+                Function caller = fm.getFunctionContaining(ref.getFromAddress());
+                if (caller != null){
+                    list.add(caller);
+                }
+            }
+        }
+        return list;
+    }
+
+    public List<Function> getFunctionCallers(Function f){
+        LinkedList<Function> list = new LinkedList<>();
+        for(Address addr: f.getBody().getAddresses(true)){
+            for(Reference ref: rm.getReferencesFrom(addr)){
+                if (ref.getReferenceType().isCall()){
+                    list.add(fm.getFunctionAt(ref.getToAddress()))
+                }
+            }
+        }
+        return list;
+    }
+
+    public List<Reference> getFunctionXRefs(Funciton f){
+        LinkedList<Reference> refs = new LinkedList<>();
+        for(Address addr: f.getBody().getAddresses(true)){
+            for(Reference r: rm.getReferencesFrom(addr)){
+                refs.add(r);
+            }
+            for(Reference r: rm.getReferencesTo(addr)){
+                refs.add(r);
+            }
+        }
+        return refs;
+    }    
+    
+    public List<CodeBlock> getFunctionBasicBlocks(Function f){
+        LinkedList<CodeBlock> list = new LinkedList<>();
+        HashSet<Long> history = new HashSet<Long>();
+        for(CodeBlock bb: bbm.getCodeBlocksContaining(f.getBody(), monitor)){
+            Long bbAddr = bb.getFirstStartAddress().getOffset();
+            if(history.contains(bbAddr)){
+                continue;
+            }
+
+            history.add(bbAddr);
+            list.add(bb);
+        }
+        return list;
+    }
 
 }

--- a/disassembler_template.py
+++ b/disassembler_template.py
@@ -134,7 +134,7 @@ class TemplateDisassm(Disassembler):
         '''Returns the arguments in the function corresponding to the function information returned from `get_func_iterator()`'''
         raise NotImplementedError
     
-    def get_func_return_type(self, addr:int, func_ctxt:Any) -> int:
+    def get_func_return_type(self, addr:int, func_ctxt:Any) -> str:
         '''Returns the return type of the function corresponding to the function information returned from `get_func_iterator()`'''
         raise NotImplementedError
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         'GitPython',
         'meson',
         'rzpipe',
-        'pyhidra',
         'tree-sitter',
         'tree-sitter-c',
         'requests',

--- a/test/test_ghidra.py
+++ b/test/test_ghidra.py
@@ -1,13 +1,9 @@
+import os
 import itertools
 import tempfile
 from urllib.request import urlopen
 
 from binocular import Ghidra, Binary
-
-# Necessary for testing
-# on close(), jpype's JVM shutdown is called and 
-# the JVM in this python process cannot be launched again 
-Ghidra._DONT_SHUTDOWN_JVM = True
 
 def test_install_release():
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -17,13 +13,16 @@ def test_install_release():
 
 def test_install_local():
     url = 'https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.2_build/ghidra_11.2_PUBLIC_20240926.zip'
-    with tempfile.TemporaryFile() as fp:
-        fp.write(urlopen(url).read())
+    tmp_file = "/tmp/binocular_temp_test_file.bin"
+    with open(tmp_file, 'wb') as f:
+        f.write(urlopen(url).read())
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            assert not Ghidra.is_installed(install_dir=tmpdirname)
-            Ghidra.install(install_dir=tmpdirname, local_install_file=fp.name)
-            assert Ghidra.is_installed(install_dir=tmpdirname)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        assert not Ghidra.is_installed(install_dir=tmpdirname)
+        Ghidra.install(install_dir=tmpdirname, local_install_file=tmp_file)
+        assert Ghidra.is_installed(install_dir=tmpdirname)
+
+    os.unlink(tmp_file)
         
 
 def test_build_commit():


### PR DESCRIPTION
- Removed pyhidra
- Added custom ghidra script to facilitate RPC from python code into ghidra
  - Opens up subprocess call to analyzeHeadless
  - Opens up TCP socket for IPC between python and java
- moved logging into a single file; project uses a single logger object now
- Fixed the local install test